### PR TITLE
Fixed typo, edited README and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,16 @@
 
 You can read this guide at https://stremio.github.io/stremio-addon-guide/
 
+## Dependencies
+
+- [Yarn](https://yarnpkg.com/)
+- [Docusaurus](https://docusaurus.io/)
+- [Webpack](https://github.com/webpack/webpack)
+
 ## Start
 
 ```
 cd website
-yarn install --development
+yarn install
 yarn start
 ```

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -46,7 +46,7 @@ The resources are basically a segmented way to build the content tree we mention
 | Resource      | Endpoint         | Description                                                                                                                                   |
 | --------      | --------         | -----------                                                                                                                                   |
 | **manifest**  | `/manifest.json` | The add-on description and capabilities.                                                                                                      |
-| **catalogs**  | `/catalog/`      | Summarized collection of meta items. Catalogs are displayed on the Srtemio **Board**. You can also browse the catalogs in the **Discover**. |
+| **catalogs**  | `/catalog/`      | Summarized collection of meta items. Catalogs are displayed on the Stremio **Board**. You can also browse the catalogs in the **Discover**. |
 | **metadata**  | `/meta/`         | Detailed description of a meta item. This description is displayed when the user selects an item form the catalog.                              |
 | **streams**   | `/stream/`       | Tells Stremio how to obtain the media content. It may be torrent info hash, HTTP URL, etc.                                                   |
 | **subtitles** | `/subtitles/`    | Subtitles resource for the chosen media.                                                                                                      |

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,9 @@
     "rename-version": "docusaurus-rename-version"
   },
   "devDependencies": {
-    "docusaurus": "^1.7.2"
+    "docusaurus": "^1.14.7"
+  },
+  "dependencies": {
+    "webpack": "^5.76.0"
   }
 }


### PR DESCRIPTION
I fixed a typo. After some searching i got the site working, it looks like `--development` in `yarn install --development` doesn't work, so I scrapped it from README. I also added dependencies which got me working because I haven't had them installed. After installing `webpack`, it added itself to `package.json` and I let it as it is.